### PR TITLE
added get method to get themes by their active status

### DIFF
--- a/WildflowerCoffeeGifts/WildflowerCoffeeGifts/Controllers/ProductThemesController.cs
+++ b/WildflowerCoffeeGifts/WildflowerCoffeeGifts/Controllers/ProductThemesController.cs
@@ -27,6 +27,16 @@ namespace WildflowerCoffeeGifts.Controllers
             return Ok(allThemes);
         }
 
+        // Get themes by status (to see only active/not deleted records or only inactive/deleted themes):
+        [HttpGet("bystatus/{isActive}")]
+        public IActionResult GetThemesByStatus(bool isActive)
+        {
+            var themesByStatus = _themeRepo.GetThemesByStatus(isActive);
+
+            return Ok(themesByStatus);
+        }
+
+
         [HttpGet("{id}")]
         public IActionResult GetThemeById(int id)
         {

--- a/WildflowerCoffeeGifts/WildflowerCoffeeGifts/DataAccess/ProductThemeRepository.cs
+++ b/WildflowerCoffeeGifts/WildflowerCoffeeGifts/DataAccess/ProductThemeRepository.cs
@@ -24,6 +24,31 @@ namespace WildflowerCoffeeGifts.DataAccess
             return allThemes;
         }
 
+        // Get themes by status so you can see active themes only (not deleted, wheree IsActive property is false/0) or deleted / aka inactive themes (where IsActive is true or 1):
+        public IEnumerable<ProductTheme> GetThemesByStatus(bool isActive)
+        {
+            using var db = new SqlConnection(_connectionString);
+
+            var sql = "select * from ProductThemes where IsActive = @isActive";
+
+            var parameters = new { isActive = isActive };
+
+            var themesByStatus = db.Query<ProductTheme>(sql, parameters);
+
+            return themesByStatus;
+        }
+
+        // Get inactive / "deleted" themes only: 
+        //public IEnumerable<ProductTheme> GetAllDeletedThemes()
+        //{
+        //    using var db = new SqlConnection(_connectionString);
+        //    var sql = "select * from ProductThemes where IsActive = 0";
+
+        //    var deletedThemes = db.Query<ProductTheme>(sql);
+
+        //    return deletedThemes;
+        //}
+
         public ProductTheme GetThemeById(int id)
         {
             using var db = new SqlConnection(_connectionString);


### PR DESCRIPTION
Added a new method to get themes by status so wee can get only active themes or only "deleted" themes. 
## To test:
1. Build and run the app.
1. Open Postman.
1. Select GET as the type.
1. Copy the right URL into Postman and add ‘api/themes/bystatus/true’ or ‘api/themes/bystatus/false’  - to get either all active/usable records or all inactive/deleted records (where that parameter is false).
1. Click Send - Expected result: You should see a list of only active themes when the url ends with `true` and a list of only inactive records when the url ends with `false`.