### PR TITLE
added View Details link on product cards

### DIFF
--- a/WildflowerCoffeeGifts/WildflowerCoffeeGifts/Models/Product.cs
+++ b/WildflowerCoffeeGifts/WildflowerCoffeeGifts/Models/Product.cs
@@ -18,6 +18,5 @@ namespace WildflowerCoffeeGifts.Models
         public int flowerArrId { get; set; }
         public int QuantityAvailable { get; set; }
         public bool IsActive { get; set; } = true;
-        public int QuantityAvailable { get; set; }
     }
 }

--- a/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/pages/Products/Products.js
+++ b/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/pages/Products/Products.js
@@ -1,10 +1,8 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 
 import './Products.scss';
 import productsData from '../../../helpers/data/productsData';
 import SingleProduct from '../../shared/SingleProduct/SingleProduct';
-// import { Link } from 'react-router-dom';
 
 class Products extends React.Component {
   state = { products: [] };
@@ -18,25 +16,10 @@ class Products extends React.Component {
     const { products } = this.state;
     const buildProducts = products.map((product) => (<SingleProduct key={product.id} product={product}/>));
 
-    const singleProductLink = '/products/2';
     return (
       <div className="d-flex flex-wrap">
-             {buildProducts}
-
-        {
-        /* //   ANCA: IMPORTANT NOTE: When the Products page and individual cards are done,
-        //   I will make the necessary updates to remove thi splaceholder info and update the links in the product cards! */
-        }
-            <div>
-                Products Page
-
-                <p>Placeholder: Link to a single product view</p>
-                <p>(this link will eventually go in the single product card layout component):</p>
-                <p>(and it will pass down the product object id in props .... I think)</p>
-              <Link to={singleProductLink}>Link to Single Product View</Link>
-
-            </div>
-            </div>
+        {buildProducts}
+      </div>
     );
   }
 }

--- a/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/pages/SingleProductView/SingleProductView.js
+++ b/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/pages/SingleProductView/SingleProductView.js
@@ -36,7 +36,7 @@ class SingleProductView extends React.Component {
                 {
                 selectedProduct.isActive
                   ? <div>
-                      <img src="selectedProduct.imageUrl" alt="flower package photo" />
+                      <img src={selectedProduct.imageUrl} alt="flower package photo" className="productImages"/>
                       <h3>Price: ${selectedProduct.price}</h3>
                       <h3>Available Quantity: {selectedProduct.quantityAvailable}</h3>
                       <h4>{selectedProduct.description}</h4>

--- a/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/pages/SingleProductView/SingleProductView.scss
+++ b/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/pages/SingleProductView/SingleProductView.scss
@@ -1,0 +1,3 @@
+.productImages {
+    max-height: 100px;
+}

--- a/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/shared/SingleProduct/SingleProduct.js
+++ b/WildflowerCoffeeGifts/wildflowercoffeegifts.ui/src/components/shared/SingleProduct/SingleProduct.js
@@ -1,9 +1,11 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import './SingleProduct.scss';
 
 class SingleProduct extends React.Component {
   render() {
     const { product } = this.props;
+    const singleProductLink = `/products/${product.id}`;
     return (
       <div>
       <div className= 'card'>
@@ -15,6 +17,7 @@ class SingleProduct extends React.Component {
            <p>Price: ${product.price}</p>
            <p>Description: {product.description}</p>
            <p>Quantities Available: {product.quantityAvailable}</p>
+           <Link to={singleProductLink}>View Details</Link>
          </div>
       </div>
       </div>


### PR DESCRIPTION
This PR includes the ability to click on a View Details link on a product and go to the single product details view page. 

To test:
1. Go to the Products page. 
1. Click the View Details link for any of the products. ***Expected result***: It should take you to the single product view page for that product. 
1. On the single view page, click the Back to Products link.   ***Expected result***: It should take you back to the Products page.